### PR TITLE
Type Agnostic Flattening

### DIFF
--- a/flatten.go
+++ b/flatten.go
@@ -111,7 +111,7 @@ func FlattenString(nestedstr, prefix string, style SeparatorStyle) (string, erro
 func flatten(top bool, flatMap map[string]interface{}, nested interface{}, prefix string, style SeparatorStyle) error {
 	assign := func(newKey string, v interface{}) error {
 		switch v.(type) {
-		case map[string]interface{}, []interface{}:
+		case map[string]interface{}, []interface{}, []string:
 			if err := flatten(false, flatMap, v, newKey, style); err != nil {
 				return err
 			}
@@ -130,6 +130,11 @@ func flatten(top bool, flatMap map[string]interface{}, nested interface{}, prefi
 		}
 	case []interface{}:
 		for i, v := range nested.([]interface{}) {
+			newKey := enkey(top, prefix, strconv.Itoa(i), style)
+			assign(newKey, v)
+		}
+	case []string:
+		for i, v := range nested.([]string) {
 			newKey := enkey(top, prefix, strconv.Itoa(i), style)
 			assign(newKey, v)
 		}


### PR DESCRIPTION
This isn't necessarily ready to be merged, but I wanted to open a discussion around the handling of explicitly typed maps and slices. At the present moment, `flatten` will only truly flatten a string (which would be unmarshalled to a `map[string]interface{}`) or a variable which has been declared as a `map[string]interface{}` or `[]interface{}`, which means that users who pass in an explicitly typed variable (e.g. `map[string]string` or `[]string`) won't receive a completely flattened object.

e.g. see #5 

The changes in this PR at the moment fix the problem for slices of strings (`[]string`) however there's a number of other explicit types that should theoretically be supported - booleans, numbers of various types, etc.

We could either explicitly support each of these, or simply try to catch them and copy to a `[]interface{}`. 